### PR TITLE
Switch to async & tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0-beta.1] - 2021-12-28
+
+### Changed
+
+- All relevant APIs are now `async`. This includes `credentials::var` and `credentials::file`. We use the `tokio` async runtime.
+- `credentials::Error` type now uses `source` instead of `cause`.
+- By default, we no longer choose an appropriate `reqwest` backend for `https`. You can enable one using `features = ["default-tls"]`, or you can directly include `reqwest` and pass `features` of your choice.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All relevant APIs are now `async`. This includes `credentials::var` and `credentials::file`. We use the `tokio` async runtime.
 - `credentials::Error` type now uses `source` instead of `cause`.
 - By default, we no longer choose an appropriate `reqwest` backend for `https`. You can enable one using `features = ["default-tls"]`, or you can directly include `reqwest` and pass `features` of your choice.
+- We use `tracing` for logging instead of `log`, mirroring the larger `tokio` ecosystem.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
 async-trait = "0.1.52"
 dirs = "4.0.0"
 lazy_static = "1.1"
-log = "0.4"
 regex = "1.0"
 reqwest = { version = "0.11.8", default-features = false, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -26,6 +25,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 thiserror = "1.0.20"
 tokio = { version = "1.15.0", default-features = false, features = ["macros"] }
+tracing = "0.1.29"
 url = "2.2.2"
 
 [dev-dependencies]
@@ -33,3 +33,4 @@ anyhow = "1"
 env_logger = "0.9.0"
 reqwest = { version = "0.11.8", default-features = false, features = ["rustls-tls-webpki-roots"] }
 tokio = { version = "1.15.0", default-features = false, features = ["rt-multi-thread"] }
+tracing-subscriber = { version = "0.3.4", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,27 @@ repository = "https://github.com/emk/credentials"
 version = "0.12.0"
 edition = "2018"
 
+[features]
+default-tls = ["rustls-tls-webpki-roots"]
+rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
+rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
+
 [dependencies]
-dirs = "2.0.1"
+async-trait = "0.1.52"
+dirs = "4.0.0"
 lazy_static = "1.1"
 log = "0.4"
 regex = "1.0"
-reqwest = "0.9.18"
-serde = "1.0"
+reqwest = { version = "0.11.8", default-features = false, features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
 thiserror = "1.0.20"
+tokio = { version = "1.15.0", default-features = false, features = ["macros"] }
+url = "2.2.2"
 
 [dev-dependencies]
-env_logger = "0.6.1"
+anyhow = "1"
+env_logger = "0.9.0"
+reqwest = { version = "0.11.8", default-features = false, features = ["rustls-tls-webpki-roots"] }
+tokio = { version = "1.15.0", default-features = false, features = ["rt-multi-thread"] }

--- a/Secretfile
+++ b/Secretfile
@@ -5,3 +5,4 @@
 #EXAMPLE_PASSWORD secret/example:password
 #PG_USERNAME postgresql/$VAULT_ENV/creds/readonly:username
 #PG_PASSWORD postgresql/$VAULT_ENV/creds/readonly:password
+TEST secret/test:value

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,36 @@
+[licenses]
+# Don't allow code with an unclear license.
+unlicensed = "deny"
+
+# Don't allow "copylefted" licenses unless they're listed below.
+copyleft = "deny"
+
+# Allow common non-restrictive licenses. ISC is used for various DNS and crypto
+# things, and it's a minimally restrictive open source license.
+allow = ["MIT", "Apache-2.0", "BSD-3-Clause", "CC0-1.0", "Zlib"]
+
+# Many organizations ban AGPL-licensed code
+# https://opensource.google/docs/using/agpl-policy/
+deny = ["AGPL-3.0"]
+
+[[licenses.clarify]]
+name = "encoding_rs"
+expression = "(MIT OR Apache-2.0) AND BSD-3-Clause AND CC0-1.0"
+license-files = [
+    { path = "COPYRIGHT", hash = 972598577 },
+]
+
+[bans]
+# Warn about multiple versions of the same crate, unless we've indicated otherwise below.
+multiple-versions = "warn"
+
+deny = [
+    # OpenSSL has caused endless deployment and build problems, and we want
+    # nothing to do with it, in any version.
+    { name = "openssl-sys" },
+]
+
+skip = [
+    # Several libraries still use the old version.
+    { name = "itoa", version = "0.4.8"},
+]

--- a/examples/credential.rs
+++ b/examples/credential.rs
@@ -3,13 +3,23 @@
 use std::env;
 
 use anyhow::Result;
+use tracing_subscriber::{
+    fmt::{format::FmtSpan, Subscriber},
+    prelude::*,
+    EnvFilter,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Enable logging.  To see what's happening, set `RUST_LOG=trace`.  It
-    // is recommended that you include and initialie `env_logger` in your
-    // programs using credentials.
-    env_logger::init();
+    // Enable tracing.  To see what's happening, set `RUST_LOG=trace`.
+    //
+    // This is optional, but very handy for debugging.
+    Subscriber::builder()
+        .with_writer(std::io::stderr)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+        .with_env_filter(EnvFilter::from_default_env())
+        .finish()
+        .init();
 
     // Print our each credential specified on the command line.
     for secret in env::args().skip(1) {

--- a/examples/credential.rs
+++ b/examples/credential.rs
@@ -1,13 +1,11 @@
 //! Look and print the credentials specified on the command line.
 
-use credentials;
-use env_logger;
-
 use std::env;
-use std::io::{self, Write};
-use std::process;
 
-fn main() {
+use anyhow::Result;
+
+#[tokio::main]
+async fn main() -> Result<()> {
     // Enable logging.  To see what's happening, set `RUST_LOG=trace`.  It
     // is recommended that you include and initialie `env_logger` in your
     // programs using credentials.
@@ -15,12 +13,9 @@ fn main() {
 
     // Print our each credential specified on the command line.
     for secret in env::args().skip(1) {
-        match credentials::var(&secret) {
-            Ok(ref value) => println!("{}={}", &secret, value),
-            Err(err) => {
-                writeln!(&mut io::stderr(), "Error: {}", err).unwrap();
-                process::exit(1);
-            }
-        }
+        let value = credentials::var(&secret).await?;
+        println!("{}={}", &secret, value);
     }
+
+    Ok(())
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -4,13 +4,18 @@ use crate::errors::*;
 use crate::secretfile::Secretfile;
 
 /// Generic interface to a secret-storage backend.
+#[async_trait::async_trait]
 pub trait Backend: Send + Sync {
     /// Return the name of this backend.
     fn name(&self) -> &'static str;
 
     /// Get the value of the specified secret.
-    fn var(&mut self, secretfile: &Secretfile, credential: &str) -> Result<String>;
+    async fn var(
+        &mut self,
+        secretfile: &Secretfile,
+        credential: &str,
+    ) -> Result<String>;
 
     /// Get the value of the specified credential file.
-    fn file(&mut self, secretfile: &Secretfile, path: &str) -> Result<String>;
+    async fn file(&mut self, secretfile: &Secretfile, path: &str) -> Result<String>;
 }

--- a/src/chained.rs
+++ b/src/chained.rs
@@ -1,6 +1,6 @@
 //! Backend which tries multiple other backends, in sequence.
 
-use log::debug;
+use tracing::debug;
 
 use crate::backend::Backend;
 use crate::envvar;
@@ -50,6 +50,7 @@ impl Backend for Client {
         "chained"
     }
 
+    #[tracing::instrument(level = "debug", skip(self, secretfile))]
     async fn var(
         &mut self,
         secretfile: &Secretfile,
@@ -70,6 +71,7 @@ impl Backend for Client {
         Err(err.unwrap_or(Error::NoBackend))
     }
 
+    #[tracing::instrument(level = "debug", skip(self, secretfile))]
     async fn file(&mut self, secretfile: &Secretfile, path: &str) -> Result<String> {
         // We want to return either the first success or the last error.
         let mut err: Option<Error> = None;

--- a/src/chained.rs
+++ b/src/chained.rs
@@ -26,13 +26,13 @@ impl Client {
     }
 
     /// Set up the standard chain, based on what appears to be available.
-    pub fn with_default_backends(allow_override: bool) -> Result<Client> {
+    pub async fn with_default_backends(allow_override: bool) -> Result<Client> {
         let mut client = Client::new();
         if vault::Client::is_enabled() {
             if allow_override {
                 client.add(envvar::Client::default()?);
             }
-            client.add(vault::Client::default()?);
+            client.add(vault::Client::default().await?);
         } else {
             client.add(envvar::Client::default()?);
         }
@@ -44,16 +44,21 @@ impl Client {
     }
 }
 
+#[async_trait::async_trait]
 impl Backend for Client {
     fn name(&self) -> &'static str {
         "chained"
     }
 
-    fn var(&mut self, secretfile: &Secretfile, credential: &str) -> Result<String> {
+    async fn var(
+        &mut self,
+        secretfile: &Secretfile,
+        credential: &str,
+    ) -> Result<String> {
         // We want to return either the first success or the last error.
         let mut err: Option<Error> = None;
         for backend in self.backends.iter_mut() {
-            match backend.var(secretfile, credential) {
+            match backend.var(secretfile, credential).await {
                 Ok(value) => {
                     return Ok(value);
                 }
@@ -65,11 +70,11 @@ impl Backend for Client {
         Err(err.unwrap_or(Error::NoBackend))
     }
 
-    fn file(&mut self, secretfile: &Secretfile, path: &str) -> Result<String> {
+    async fn file(&mut self, secretfile: &Secretfile, path: &str) -> Result<String> {
         // We want to return either the first success or the last error.
         let mut err: Option<Error> = None;
         for backend in self.backends.iter_mut() {
-            match backend.file(secretfile, path) {
+            match backend.file(secretfile, path).await {
                 Ok(value) => {
                     return Ok(value);
                 }
@@ -101,12 +106,13 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl Backend for DummyClient {
         fn name(&self) -> &'static str {
             "dummy"
         }
 
-        fn var(
+        async fn var(
             &mut self,
             _secretfile: &Secretfile,
             credential: &str,
@@ -118,7 +124,11 @@ mod tests {
             }
         }
 
-        fn file(&mut self, _secretfile: &Secretfile, path: &str) -> Result<String> {
+        async fn file(
+            &mut self,
+            _secretfile: &Secretfile,
+            path: &str,
+        ) -> Result<String> {
             if path == "dummy.txt" {
                 Ok("dummy2".to_owned())
             } else {
@@ -127,19 +137,19 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_chaining() {
+    #[tokio::test]
+    async fn test_chaining() {
         let sf = Secretfile::from_str("").unwrap();
         let mut client = Client::new();
         client.add(envvar::Client::default().unwrap());
         client.add(DummyClient::default().unwrap());
 
         env::set_var("FOO_USERNAME", "user");
-        assert_eq!("user", client.var(&sf, "FOO_USERNAME").unwrap());
-        assert_eq!("dummy", client.var(&sf, "DUMMY").unwrap());
-        assert!(client.var(&sf, "NOSUCHVAR").is_err());
+        assert_eq!("user", client.var(&sf, "FOO_USERNAME").await.unwrap());
+        assert_eq!("dummy", client.var(&sf, "DUMMY").await.unwrap());
+        assert!(client.var(&sf, "NOSUCHVAR").await.is_err());
 
-        assert_eq!("dummy2", client.file(&sf, "dummy.txt").unwrap());
-        assert!(client.file(&sf, "nosuchfile.txt").is_err());
+        assert_eq!("dummy2", client.file(&sf, "dummy.txt").await.unwrap());
+        assert!(client.file(&sf, "nosuchfile.txt").await.is_err());
     }
 }

--- a/src/envvar.rs
+++ b/src/envvar.rs
@@ -1,9 +1,9 @@
 //! A backend which reads from environment variables.
 
-use log::debug;
 use std::env;
 use std::fs;
 use std::io::Read;
+use tracing::debug;
 
 use crate::backend::Backend;
 use crate::errors::*;
@@ -25,6 +25,7 @@ impl Backend for Client {
         "env"
     }
 
+    #[tracing::instrument(level = "trace", skip(self, _secretfile))]
     async fn var(
         &mut self,
         _secretfile: &Secretfile,
@@ -40,6 +41,7 @@ impl Backend for Client {
         Ok(value)
     }
 
+    #[tracing::instrument(level = "trace", skip(self, _secretfile))]
     async fn file(&mut self, _secretfile: &Secretfile, path: &str) -> Result<String> {
         let mut f = fs::File::open(path)?;
         let mut contents = String::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@
 
 use backend::Backend;
 use lazy_static::lazy_static;
-use log::trace;
 use std::convert::AsRef;
 use std::default::Default;
 use std::future::Future;
@@ -27,6 +26,7 @@ use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use tracing::trace;
 
 // Be very careful not to export any more of the Secretfile API than
 // strictly necessary, because we don't want to stablize too much at this

--- a/src/secretfile.rs
+++ b/src/secretfile.rs
@@ -54,11 +54,11 @@ fn interpolate_env(text: &str) -> Result<String> {
             .unwrap()
             .as_str();
         match env::var(name) {
-            Ok(s) => s.to_owned(),
+            Ok(s) => s,
             Err(env_err) => {
                 err = Some(Error::UndefinedEnvironmentVariable {
                     name: name.to_owned(),
-                    cause: env_err,
+                    source: env_err,
                 });
                 "".to_owned()
             }
@@ -85,7 +85,7 @@ pub enum Location {
 impl Location {
     /// Create a new `Location` from a regex `Captures` containing the
     /// named match `path` and optionally `key`.
-    fn from_caps<'a>(caps: &Captures<'a>) -> Result<Location> {
+    fn from_caps(caps: &Captures<'_>) -> Result<Location> {
         let path_opt = caps.name("path").map(|m| m.as_str());
         let key_opt = caps.name("key").map(|m| m.as_str());
         match (path_opt, key_opt) {
@@ -176,11 +176,11 @@ impl Secretfile {
         let path = path.as_ref();
         let mut file = File::open(path).map_err(|err| Error::FileRead {
             path: path.to_owned(),
-            cause: Box::new(err.into()),
+            source: Box::new(err.into()),
         })?;
         Secretfile::read(&mut file).map_err(|err| Error::FileRead {
             path: path.to_owned(),
-            cause: Box::new(err),
+            source: Box::new(err),
         })
     }
 
@@ -289,14 +289,14 @@ fn test_parse() {
     let data = "\
 # This is a comment.
 
-FOO_USERNAME secret/$SECRET_NAME:username\n\
-FOO_PASSWORD secret/${SECRET_NAME}:password\n\
+FOO_USERNAME secret/$SECRET_NAME:username
+FOO_PASSWORD secret/${SECRET_NAME}:password
 
 # Try a Keywhiz-style secret, too.
-FOO_USERNAME2 ${SECRET_NAME}_username\n\
+FOO_USERNAME2 ${SECRET_NAME}_username
 
 # Credentials to copy to a file.  Interpolation allowed on the left here.
->$SOMEDIR/.conf/key.pem secret/ssl:key_pem\n\
+>$SOMEDIR/.conf/key.pem secret/ssl:key_pem
 ";
     env::set_var("SECRET_NAME", "foo");
     env::set_var("SOMEDIR", "/home/foo");

--- a/src/vault/kubernetes.rs
+++ b/src/vault/kubernetes.rs
@@ -1,9 +1,6 @@
-use reqwest;
 use serde::{Deserialize, Serialize};
-use serde_json;
 use std::env;
 use std::fs;
-use std::io::prelude::*;
 use std::path::Path;
 
 use crate::errors::*;
@@ -18,7 +15,7 @@ const KUBERNETES_TOKEN_PATH: &str =
 fn kubernetes_jwt() -> Result<String> {
     fs::read_to_string(KUBERNETES_TOKEN_PATH).map_err(|err| Error::FileRead {
         path: Path::new(KUBERNETES_TOKEN_PATH).to_owned(),
-        cause: Box::new(err.into()),
+        source: Box::new(err.into()),
     })
 }
 
@@ -44,7 +41,7 @@ struct VaultAuth {
 }
 
 /// Authenticate against the specified Kubernetes auth endpoint.
-fn auth(
+async fn auth(
     client: reqwest::Client,
     addr: &reqwest::Url,
     auth_path: &str,
@@ -55,9 +52,9 @@ fn auth(
     let payload = VaultKubernetesLogin { role, jwt };
     let mkerr = |err| Error::Url {
         url: url.to_owned(),
-        cause: Box::new(err),
+        source: Box::new(err),
     };
-    let mut res = client
+    let res = client
         .post(url.clone())
         // Leaving the connection open will cause errors on reconnect
         // after inactivity.
@@ -66,19 +63,25 @@ fn auth(
         .header("Connection", "close")
         .body(serde_json::to_vec(&payload)?)
         .send()
+        .await
         .map_err(|err| (&mkerr)(Error::Other(err.into())))?;
-
-    // Read our HTTP body.
-    let mut body = String::new();
-    res.read_to_string(&mut body)?;
 
     if res.status().is_success() {
         // Parse our body and get the auth token.
-        let auth_res: VaultAuthResponse = serde_json::from_str(&body)?;
+        // Read our HTTP body.
+        let auth_res = res
+            .json::<VaultAuthResponse>()
+            .await
+            .map_err(|err| (&mkerr)(Error::Other(err.into())))?;
         Ok(auth_res.auth.client_token)
     } else {
         // Generate informative errors for HTTP failures.
         let status = res.status().to_owned();
+        let body = res
+            .text()
+            .await
+            .map_err(|err| (&mkerr)(Error::Other(err.into())))?;
+
         Err(mkerr(Error::UnexpectedHttpStatus {
             status,
             body: body.trim().to_owned(),
@@ -88,7 +91,9 @@ fn auth(
 
 /// If `VAULT_KUBERNETES_ROLE` is set, attempt to get a Vault token by
 /// logging into Vault using our Kubernetes credentials.
-pub(crate) fn vault_kubernetes_token(addr: &reqwest::Url) -> Result<Option<String>> {
+pub(crate) async fn vault_kubernetes_token(
+    addr: &reqwest::Url,
+) -> Result<Option<String>> {
     let role = match env::var("VAULT_KUBERNETES_ROLE") {
         Ok(role) => role,
         Err(_) => return Ok(None),
@@ -97,5 +102,5 @@ pub(crate) fn vault_kubernetes_token(addr: &reqwest::Url) -> Result<Option<Strin
         .unwrap_or_else(|_| "kubernetes".to_owned());
     let jwt = kubernetes_jwt()?;
     let client = reqwest::Client::new();
-    Ok(Some(auth(client, addr, &auth_path, &role, &jwt)?))
+    Ok(Some(auth(client, addr, &auth_path, &role, &jwt).await?))
 }

--- a/src/vault/kubernetes.rs
+++ b/src/vault/kubernetes.rs
@@ -41,6 +41,7 @@ struct VaultAuth {
 }
 
 /// Authenticate against the specified Kubernetes auth endpoint.
+#[tracing::instrument(level = "trace", skip(client, jwt))]
 async fn auth(
     client: reqwest::Client,
     addr: &reqwest::Url,

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -1,10 +1,8 @@
 //! A very basic client for Hashicorp's Vault
 
-use dirs;
 use log::debug;
 use reqwest::{self, Url};
 use serde::Deserialize;
-use serde_json;
 use std::collections::BTreeMap;
 use std::env;
 use std::fs::File;
@@ -24,14 +22,14 @@ fn default_addr() -> Result<String> {
 }
 
 /// The default vault token.
-fn default_token(addr: &reqwest::Url) -> Result<String> {
-    // Wrap everything in a local function and call it so that
-    // we can wrap all errors in a custom type.
-    (|| -> Result<String> {
+async fn default_token(addr: &reqwest::Url) -> Result<String> {
+    // Wrap everything in a local async block and await it so that we can wrap
+    // all errors in a custom type.
+    let fut = async {
         if let Ok(token) = env::var("VAULT_TOKEN") {
             // The env var `VAULT_TOKEN` overrides everything.
             Ok(token)
-        } else if let Some(token) = vault_kubernetes_token(addr)? {
+        } else if let Some(token) = vault_kubernetes_token(addr).await? {
             // We were able to get a token using our Kubernetes JWT
             // token.
             Ok(token)
@@ -46,8 +44,9 @@ fn default_token(addr: &reqwest::Url) -> Result<String> {
             f.read_to_string(&mut token)?;
             Ok(token)
         }
-    })()
-    .map_err(|err| Error::MissingVaultToken(Box::new(err)))
+    };
+    fut.await
+        .map_err(|err| Error::MissingVaultToken(Box::new(err)))
 }
 
 /// Secret data retrieved from Vault.  This has a bunch more fields, but
@@ -58,6 +57,7 @@ struct Secret {
     /// The key-value pairs associated with this secret.
     data: BTreeMap<String, String>,
     // How long this secret will remain valid for, in seconds.
+    #[allow(dead_code)]
     lease_duration: u64,
 }
 
@@ -82,10 +82,10 @@ impl Client {
     /// Construct a new vault::Client, attempting to use the same
     /// environment variables and files used by the `vault` CLI tool and
     /// the Ruby `vault` gem.
-    pub fn default() -> Result<Client> {
+    pub async fn default() -> Result<Client> {
         let client = reqwest::Client::new();
         let addr = default_addr()?.parse()?;
-        let token = default_token(&addr)?;
+        let token = default_token(&addr).await?;
         Client::new(client, addr, token)
     }
 
@@ -104,15 +104,15 @@ impl Client {
     }
 
     /// Fetch a secret from the Vault server.
-    fn get_secret(&self, path: &str) -> Result<Secret> {
+    async fn get_secret(&self, path: &str) -> Result<Secret> {
         let url = self.addr.join(&format!("v1/{}", path))?;
         debug!("Getting secret {}", url);
 
         let mkerr = |err| Error::Url {
             url: url.clone(),
-            cause: Box::new(err),
+            source: Box::new(err),
         };
-        let mut res = self
+        let res = self
             .client
             .get(url.clone())
             // Leaving the connection open will cause errors on reconnect
@@ -120,19 +120,24 @@ impl Client {
             .header("Connection", "close")
             .header("X-Vault-Token", &self.token[..])
             .send()
+            .await
             .map_err(|err| (&mkerr)(Error::Other(err.into())))?;
 
-        // Read our HTTP body.
-        let mut body = String::new();
-        res.read_to_string(&mut body)?;
-
         if res.status().is_success() {
-            Ok(serde_json::from_str(&body)?)
+            Ok(res
+                .json()
+                .await
+                .map_err(|err| (&mkerr)(Error::Other(err.into())))?)
         } else {
             // Generate informative errors for HTTP failures, because these can
             // be caused by everything from bad URLs to overly restrictive vault
             // policies.
             let status = res.status().to_owned();
+            let body = res
+                .text()
+                .await
+                .map_err(|err| (&mkerr)(Error::Other(err.into())))?;
+
             Err(mkerr(Error::UnexpectedHttpStatus {
                 status,
                 body: body.trim().to_owned(),
@@ -140,7 +145,7 @@ impl Client {
         }
     }
 
-    fn get_loc(
+    async fn get_loc(
         &mut self,
         searched_for: &str,
         loc: Option<Location>,
@@ -156,7 +161,7 @@ impl Client {
                 // secret, and fetching the secret once per key will result
                 // in mismatched username/password pairs or whatever.
                 if !self.secrets.contains_key(path) {
-                    let secret = self.get_secret(path)?;
+                    let secret = self.get_secret(path).await?;
                     self.secrets.insert(path.to_owned(), secret);
                 }
 
@@ -181,19 +186,24 @@ impl Client {
     }
 }
 
+#[async_trait::async_trait]
 impl Backend for Client {
     fn name(&self) -> &'static str {
         "vault"
     }
 
-    fn var(&mut self, secretfile: &Secretfile, credential: &str) -> Result<String> {
+    async fn var(
+        &mut self,
+        secretfile: &Secretfile,
+        credential: &str,
+    ) -> Result<String> {
         let loc = secretfile.var(credential).cloned();
-        self.get_loc(credential, loc)
+        self.get_loc(credential, loc).await
     }
 
-    fn file(&mut self, secretfile: &Secretfile, path: &str) -> Result<String> {
+    async fn file(&mut self, secretfile: &Secretfile, path: &str) -> Result<String> {
         let loc = secretfile.file(path).cloned();
-        self.get_loc(path, loc)
+        self.get_loc(path, loc).await
     }
 }
 

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -1,12 +1,12 @@
 //! A very basic client for Hashicorp's Vault
 
-use log::debug;
 use reqwest::{self, Url};
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::env;
 use std::fs::File;
 use std::io::Read;
+use tracing::debug;
 
 use crate::backend::Backend;
 use crate::errors::*;
@@ -192,6 +192,7 @@ impl Backend for Client {
         "vault"
     }
 
+    #[tracing::instrument(level = "trace", skip(self, secretfile))]
     async fn var(
         &mut self,
         secretfile: &Secretfile,
@@ -201,6 +202,7 @@ impl Backend for Client {
         self.get_loc(credential, loc).await
     }
 
+    #[tracing::instrument(level = "trace", skip(self, secretfile))]
     async fn file(&mut self, secretfile: &Secretfile, path: &str) -> Result<String> {
         let loc = secretfile.file(path).cloned();
         self.get_loc(path, loc).await


### PR DESCRIPTION
This PR updates all of our dependencies. Additionally:

1. It changes all APIs to use `async` where appropriate.
2. It replaces `log` with `tracing`.
3. It no longer selects a default SSL backend for `reqwest`, making it
   possible to use RusTLS, etc., if desired.
