### PR TITLE
readme: remove now broken Keywhiz link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ which would make it much easier to accidentally reveal them to the world.
 
 But once your application deployment becomes more complex, it's much easier
 to store passwords in a central, secure store such as Hashicorp's
-[Vault][vault] or Square's [Keywhiz][keywhiz].
+[Vault][vault].
 
 Wherever you choose to store your secrets, this library is intended to
 provide a single, unified API:


### PR DESCRIPTION
Keywhiz support was excluded from the scope of this project at https://github.com/emk/credentials/commit/da6494be001544662a13726e83575090d452e544. However, an oversight left a broken link to its homepage in the initial paragraphs of the README. This PR rectifies that by removing the last remaining user-visible mention of Keywhiz.