### PR TITLE
Update and modernify dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,22 +15,22 @@ rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
 rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
 
 [dependencies]
-async-trait = "0.1.52"
-dirs = "4.0.0"
-lazy_static = "1.1"
-regex = "1.0"
-reqwest = { version = "0.11.8", default-features = false, features = ["json"] }
+async-trait = "0.1.77"
+home = "0.5.9"
+once_cell = "1.19.0"
+regex = "1.10"
+reqwest = { version = "0.11.23", default-features = false, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
-thiserror = "1.0.20"
-tokio = { version = "1.15.0", default-features = false, features = ["macros"] }
-tracing = "0.1.29"
-url = "2.2.2"
+thiserror = "1.0.56"
+tokio = { version = "1.35.1", default-features = false }
+tracing = "0.1.40"
+url = "2.5.0"
 
 [dev-dependencies]
 anyhow = "1"
-env_logger = "0.9.0"
-reqwest = { version = "0.11.8", default-features = false, features = ["rustls-tls-native-roots"] }
-tokio = { version = "1.15.0", default-features = false, features = ["rt-multi-thread"] }
-tracing-subscriber = { version = "0.3.4", features = ["env-filter"] }
+env_logger = "0.10.1"
+reqwest = { version = "0.11.23", default-features = false, features = ["rustls-tls-native-roots"] }
+tokio = { version = "1.35.1", default-features = false, features = ["macros", "rt-multi-thread"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,8 @@
+# dev dependencies are not linked for crate users, and currently
+# cause lots of multiple version warning noise for Windows API
+# crates
+exclude-dev = true
+
 [licenses]
 # Don't allow code with an unclear license.
 unlicensed = "deny"
@@ -7,7 +12,7 @@ copyleft = "deny"
 
 # Allow common non-restrictive licenses. ISC is used for various DNS and crypto
 # things, and it's a minimally restrictive open source license.
-allow = ["MIT", "Apache-2.0", "BSD-3-Clause", "CC0-1.0", "ISC", "OpenSSL", "Zlib"]
+allow = ["MIT", "Apache-2.0", "BSD-3-Clause", "CC0-1.0", "ISC", "OpenSSL", "Zlib", "Unicode-DFS-2016"]
 
 # Many organizations ban AGPL-licensed code
 # https://opensource.google/docs/using/agpl-policy/
@@ -36,9 +41,4 @@ deny = [
     # OpenSSL has caused endless deployment and build problems, and we want
     # nothing to do with it, in any version.
     { name = "openssl-sys" },
-]
-
-skip = [
-    # Several libraries still use the old version.
-    { name = "itoa", version = "0.4.8"},
 ]

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -35,7 +35,7 @@ async fn default_token(addr: &reqwest::Url) -> Result<String> {
             Ok(token)
         } else {
             // Build a path to ~/.vault-token.
-            let mut path = dirs::home_dir().ok_or(Error::NoHomeDirectory)?;
+            let mut path = home::home_dir().ok_or(Error::NoHomeDirectory)?;
             path.push(".vault-token");
 
             // Read the file.


### PR DESCRIPTION
While I was working on other PRs, I noticed that this crate depended on slightly older versions of crates, so I took the initiative to update all of the dependencies :smile: 

This PR is not meant to alter any functionality of this crate. Some assorted highlights about it include:

- I've replaced the `dirs` dependency with the functionally-equivalent `home`. This decision was driven by the fact you already know [that its latest version transitively pulls a dependency on a copylefted crate](https://github.com/dirs-dev/dirs-rs/issues/51), and the [repeated refusal of upstream to do something about it](https://github.com/dirs-dev/dirs-sys-rs/pull/26). `home` is maintained by the official Rust language team, making it more likely to keep its licensing in check for the foreseeable future.
- I've swapped out `lazy_static` with `once_cell`. The latter eliminates the need for the cumbersome macro syntax and aligns more closely with what the Rust standard library may eventually stabilize. Thus, it's currently considered the best choice.
- I got rid of an unnecessary `tokio` feature for library usage.
- I executed `cargo deny` and updated its configuration file accordingly.
- Unnecessary wrapping of global variables with `RefCell` and `Arc` was eliminated.