### PR TITLE
Enable TLS support by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ version = "1.0.0-beta.1"
 edition = "2018"
 
 [features]
+default = ["default-tls"]
+
 default-tls = ["rustls-tls-webpki-roots"]
 rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
 rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]


### PR DESCRIPTION
It is currently considered a best practice to employ HTTPS for all HTTP exchanges, and this becomes particularly crucial when handling sensitive secrets. Sadly, the default feature flags of this crate may not facilitate the seamless use of HTTPS if newer dependencies are used (c.f. #5): TLS support is not explicitly enabled by default, resulting in `https` URLs being unsupported with a [rather cryptic error message](https://github.com/hyperium/hyper/issues/1009).

To improve the ergonomics of this crate in common scenarios, let's explicitly enable TLS support by default. Users with specific requirements can still choose to opt out of this support by explicitly disabling the default features of this crate in their `Cargo.toml` file.